### PR TITLE
add new encryption library

### DIFF
--- a/angler/proprietary-blobs.txt
+++ b/angler/proprietary-blobs.txt
@@ -334,6 +334,7 @@ vendor/lib64/libvoice-svc.so
 vendor/lib64/libwms.so
 vendor/lib64/libxml.so
 vendor/lib64/mediadrm/libdrmclearkeyplugin.so
+vendor/lib64/libkmcrypto.so
 vendor/lib/egl/eglSubDriverAndroid.so
 vendor/lib/egl/libEGL_adreno.so
 vendor/lib/egl/libGLESv1_CM_adreno.so
@@ -578,6 +579,7 @@ vendor/lib/libWVStreamControlAPI_L1.so
 vendor/lib/libxml.so
 vendor/lib/mediadrm/libdrmclearkeyplugin.so
 vendor/lib/mediadrm/libwvdrmengine.so
+vendor/lib/libkmcrypto.so
 vendor/media/LMspeed_508.emd
 vendor/media/PFFprec_600.emd
 vendor/pittpatt/models/detection/multi_pose_face_landmark_detectors.8/landmark_group_meta_data.bin

--- a/bullhead/proprietary-blobs.txt
+++ b/bullhead/proprietary-blobs.txt
@@ -410,6 +410,7 @@ vendor/lib/mediadrm/libdrmclearkeyplugin.so
 vendor/lib/libmmcamera_isp_linearization40.so
 vendor/lib/libllvm-qcom.so
 vendor/lib/libgoog_rownr.so
+vendor/lib/libkmcrypto.so
 vendor/media/PFFprec_600.emd
 vendor/media/LMspeed_508.emd
 vendor/pittpatt/models/detection/multi_pose_face_landmark_detectors.8/landmark_group_meta_data.bin
@@ -536,6 +537,7 @@ vendor/lib64/lib-rtpdaemoninterface.so
 vendor/lib64/libdrmtime.so
 vendor/lib64/mediadrm/libdrmclearkeyplugin.so
 vendor/lib64/libllvm-qcom.so
+vendor/lib64/libkmcrypto.so
 vendor/etc/msm_irqbalance.conf
 vendor/etc/perf-profile0.conf
 vendor/etc/audio_effects.conf


### PR DESCRIPTION
This is needed to boot encrypted devices with the new branch for the
Nexus 5X and 6P.