### PR TITLE
Force English to grep fdisk output

### DIFF
--- a/scripts/extract-factory-images.sh
+++ b/scripts/extract-factory-images.sh
@@ -41,7 +41,7 @@ extract_vendor_partition_size() {
   local OUT_FILE="$2/vendor_partition_size"
   local size=""
 
-  size="$(fdisk -l "$VENDOR_IMG_RAW" | egrep 'Disk.*bytes' | cut -d ',' -f2 | cut -d ' ' -f2)"
+  size="$(LANG=C fdisk -l "$VENDOR_IMG_RAW" | egrep 'Disk.*bytes' | cut -d ',' -f2 | cut -d ' ' -f2)"
   if [[ "$size" == "" ]]; then
     echo "[!] Failed to extract vendor partition size from '$VENDOR_IMG_RAW'"
     abort 1


### PR DESCRIPTION
The vendor partition size is extracted from fdisk output. However, since
the output is localized, egrep will fail on non-English systems.

Therefore, force English language for the fdisk command.