### PR TITLE
include vendor partition in marlin/sailfish OTAs

### DIFF
--- a/scripts/generate-vendor.sh
+++ b/scripts/generate-vendor.sh
@@ -359,6 +359,7 @@ gen_board_family_cfg_mk() {
 
   if [[ "$DEVICE_FAMILY" == "marlin" ]]; then
     {
+      echo 'AB_OTA_PARTITIONS += vendor'
       echo 'ifneq ($(filter sailfish,$(TARGET_DEVICE)),)'
       echo '  LOCAL_STEM := sailfish/BoardConfigVendorPartial.mk'
       echo 'else'


### PR DESCRIPTION
The vendor partition needs to be added to AB_OTA_PARTITIONS or OTA
updates do not include vendor and only end up updating system. The
dm-verity data for the vendor partition is updated either way, so
this usually ends up leading to a verified boot failure.