### PR TITLE
remove hard-wired vendor LOCAL_DEX_PREOPT := false

### DIFF
--- a/scripts/generate-vendor.sh
+++ b/scripts/generate-vendor.sh
@@ -636,7 +636,7 @@ gen_mk_for_bytecode() {
         echo "$priv"
       fi
       echo "LOCAL_MODULE_SUFFIX := $suffix"
-      if [[ "$ALLOW_PREOPT" = false || "$RELROOT" == "vendor" ]]; then
+      if [[ "$ALLOW_PREOPT" = false ]]; then
         echo "LOCAL_DEX_PREOPT := false"
       fi
 


### PR DESCRIPTION
The AOSP build system already avoids optimizing apks outside of system:

https://android.googlesource.com/platform/build.git/+/edfd55ae999eb7bfc932cfa88a1a8dcd6bad1169

Relying on the AOSP build system for this will allow CopperheadOS to
enable optimization outside system without changing
android-prepare-vendor.