### PR TITLE
add libfmas.so for marlin / sailfish

### DIFF
--- a/marlin/config-full/system-proprietary-blobs-api25.txt
+++ b/marlin/config-full/system-proprietary-blobs-api25.txt
@@ -131,5 +131,6 @@ system/lib/libloc_eng.so
 system/lib/libminui.so
 system/lib/libmm-qcamera.so
 system/lib/libtinyxml.so
+system/lib/soundfx/libfmas.so
 system/usr/qfipsverify/bootimg.hmac
 system/usr/qfipsverify/qfipsverify.hmac

--- a/marlin/config-naked/system-proprietary-blobs-api25.txt
+++ b/marlin/config-naked/system-proprietary-blobs-api25.txt
@@ -124,5 +124,6 @@ system/lib/libloc_eng.so
 system/lib/libminui.so
 system/lib/libmm-qcamera.so
 system/lib/libtinyxml.so
+system/lib/soundfx/libfmas.so
 system/usr/qfipsverify/bootimg.hmac
 system/usr/qfipsverify/qfipsverify.hmac

--- a/sailfish/config-full/system-proprietary-blobs-api25.txt
+++ b/sailfish/config-full/system-proprietary-blobs-api25.txt
@@ -131,5 +131,6 @@ system/lib/libloc_eng.so
 system/lib/libminui.so
 system/lib/libmm-qcamera.so
 system/lib/libtinyxml.so
+system/lib/soundfx/libfmas.so
 system/usr/qfipsverify/bootimg.hmac
 system/usr/qfipsverify/qfipsverify.hmac

--- a/sailfish/config-naked/system-proprietary-blobs-api25.txt
+++ b/sailfish/config-naked/system-proprietary-blobs-api25.txt
@@ -124,5 +124,6 @@ system/lib/libloc_eng.so
 system/lib/libminui.so
 system/lib/libmm-qcamera.so
 system/lib/libtinyxml.so
+system/lib/soundfx/libfmas.so
 system/usr/qfipsverify/bootimg.hmac
 system/usr/qfipsverify/qfipsverify.hmac


### PR DESCRIPTION
This is used by the standard /vendor/etc/audio_effects.conf and an error
is triggered since it's missing:

    08-05 23:35:38.287   511   511 W EffectsFactory: loadLibrary() failed to open /system/lib/soundfx/libfmas.so
    08-05 23:35:38.295   511   511 W EffectsFactory: loadEffect() could not get library fmas
    08-05 23:35:38.296   511   511 W EffectsFactory: loadEffect() could not get library fmas
    08-05 23:35:38.298   511   511 W BufferProvider: unable to find downmix effect

A consequence of this is that the MusicFX Equalizer feature doesn't
currently work.