### PR TITLE
leave out CarrierSetup for Pixel naked config

### DIFF
--- a/marlin/config-naked/bytecode-proprietary-api26.txt
+++ b/marlin/config-naked/bytecode-proprietary-api26.txt
@@ -1,7 +1,6 @@
 # Bytecode archive files to extract from factory images
 
 # Radio
-system/priv-app/CarrierSetup/CarrierSetup.apk
 system/priv-app/CNEService/CNEService.apk
 system/priv-app/DiagMon/DiagMon.apk
 system/priv-app/qcrilmsgtunnel/qcrilmsgtunnel.apk

--- a/sailfish/config-naked/bytecode-proprietary-api26.txt
+++ b/sailfish/config-naked/bytecode-proprietary-api26.txt
@@ -1,7 +1,6 @@
 # Bytecode archive files to extract from factory images
 
 # Radio
-system/priv-app/CarrierSetup/CarrierSetup.apk
 system/priv-app/CNEService/CNEService.apk
 system/priv-app/DiagMon/DiagMon.apk
 system/priv-app/qcrilmsgtunnel/qcrilmsgtunnel.apk


### PR DESCRIPTION
CarrierSetup doesn't appear to have any use in the naked configuration
build. It depends on Verizon code that's not included and is triggered
by configuration in the GoogleCarrierConfig vendor.xml not present in
AOSP. CopperheadOS includes the stock vendor.xml as an overlay, but
leaves out the Verizon configuration since it depends on the app suite
and isn't required for basic LTE+ functionality without VoLTE / VoWiFi.

The permissions whitelist for CarrierSetup is also in the file for
Google Play Services (privapp-permissions-google.xml) rather than the
one for the Pixels (privapp-permissions-marlin.xml). If it's included,
that whitelist needs to be included too.