### PR TITLE
no longer need to override Pixel fstab

### DIFF
--- a/marlin/config-full/vendor-config-api26.txt
+++ b/marlin/config-full/vendor-config-api26.txt
@@ -1,8 +1,1 @@
 # Additional flags to be inserted at generated BoardConfigVendor.mk
-
-# Enable back dm-verity verify for /vendor partition. This hack is to
-# effectively override the results of the following commit in AOSP
-# https://android.googlesource.com/device/google/marlin/+/062dfea3bd94177f7e24f7b08b4edce4006ae9b6
-PRODUCT_COPY_FILES := \
-    device/google/marlin/fstab.common:root/fstab.marlin \
-    $(PRODUCT_COPY_FILES)

--- a/marlin/config-naked/vendor-config-api26.txt
+++ b/marlin/config-naked/vendor-config-api26.txt
@@ -1,8 +1,1 @@
 # Additional flags to be inserted at generated BoardConfigVendor.mk
-
-# Enable back dm-verity verify for /vendor partition. This hack is to
-# effectively override the results of the following commit in AOSP
-# https://android.googlesource.com/device/google/marlin/+/062dfea3bd94177f7e24f7b08b4edce4006ae9b6
-PRODUCT_COPY_FILES := \
-    device/google/marlin/fstab.common:root/fstab.marlin \
-    $(PRODUCT_COPY_FILES)

--- a/sailfish/config-full/vendor-config-api26.txt
+++ b/sailfish/config-full/vendor-config-api26.txt
@@ -1,8 +1,1 @@
 # Additional flags to be inserted at generated BoardConfigVendor.mk
-
-# Enable back dm-verity verify for /vendor partition. This hack is to
-# effectively override the results of the following commit in AOSP
-# https://android.googlesource.com/device/google/marlin/+/062dfea3bd94177f7e24f7b08b4edce4006ae9b6
-PRODUCT_COPY_FILES := \
-    device/google/marlin/fstab.common:root/fstab.sailfish \
-    $(PRODUCT_COPY_FILES)

--- a/sailfish/config-naked/vendor-config-api26.txt
+++ b/sailfish/config-naked/vendor-config-api26.txt
@@ -1,8 +1,1 @@
 # Additional flags to be inserted at generated BoardConfigVendor.mk
-
-# Enable back dm-verity verify for /vendor partition. This hack is to
-# effectively override the results of the following commit in AOSP
-# https://android.googlesource.com/device/google/marlin/+/062dfea3bd94177f7e24f7b08b4edce4006ae9b6
-PRODUCT_COPY_FILES := \
-    device/google/marlin/fstab.common:root/fstab.sailfish \
-    $(PRODUCT_COPY_FILES)


### PR DESCRIPTION
Google removed the vendor partition from fstab and put it in the device
tree as part of Treble, where it has verity enabled:

https://android.googlesource.com/kernel/msm.git/+/31dc3c7d67fa22330856a982b2cd1e6b97feda21

They also moved fstab from root to vendor, so this is installing it to
the old location.

Nexus devices still need this hack.