### PR TITLE
build nanotool from source

### DIFF
--- a/marlin/config-full/modules-force-api26.txt
+++ b/marlin/config-full/modules-force-api26.txt
@@ -1,3 +1,4 @@
 com.android.ims.rcsmanager
+nanotool
 PresencePolling
 RcsService

--- a/marlin/config-full/system-proprietary-blobs-api26.txt
+++ b/marlin/config-full/system-proprietary-blobs-api26.txt
@@ -1,5 +1,4 @@
 system/bin/mct-unit-test-app
-system/bin/nanotool
 system/bin/pktlogconf
 system/bin/qmi_simple_ril_test
 system/bin/test_bet_8996

--- a/marlin/config-naked/modules-force-api26.txt
+++ b/marlin/config-naked/modules-force-api26.txt
@@ -1,3 +1,4 @@
 com.android.ims.rcsmanager
+nanotool
 PresencePolling
 RcsService

--- a/marlin/config-naked/system-proprietary-blobs-api26.txt
+++ b/marlin/config-naked/system-proprietary-blobs-api26.txt
@@ -1,5 +1,4 @@
 system/bin/mct-unit-test-app
-system/bin/nanotool
 system/bin/pktlogconf
 system/bin/qmi_simple_ril_test
 system/bin/test_bet_8996

--- a/sailfish/config-full/modules-force-api26.txt
+++ b/sailfish/config-full/modules-force-api26.txt
@@ -1,3 +1,4 @@
 com.android.ims.rcsmanager
+nanotool
 PresencePolling
 RcsService

--- a/sailfish/config-full/system-proprietary-blobs-api26.txt
+++ b/sailfish/config-full/system-proprietary-blobs-api26.txt
@@ -1,5 +1,4 @@
 system/bin/mct-unit-test-app
-system/bin/nanotool
 system/bin/pktlogconf
 system/bin/qmi_simple_ril_test
 system/bin/test_bet_8996

--- a/sailfish/config-naked/modules-force-api26.txt
+++ b/sailfish/config-naked/modules-force-api26.txt
@@ -1,3 +1,4 @@
 com.android.ims.rcsmanager
+nanotool
 PresencePolling
 RcsService

--- a/sailfish/config-naked/system-proprietary-blobs-api26.txt
+++ b/sailfish/config-naked/system-proprietary-blobs-api26.txt
@@ -1,5 +1,4 @@
 system/bin/mct-unit-test-app
-system/bin/nanotool
 system/bin/pktlogconf
 system/bin/qmi_simple_ril_test
 system/bin/test_bet_8996


### PR DESCRIPTION
AOSP includes nanotool but only usually builds it in userdebug / eng
builds unlike stock where it's in the published user build.