### PR TITLE
use rcsmanager permissions whitelist from AOSP

### DIFF
--- a/marlin/config-full/system-proprietary-blobs-api26.txt
+++ b/marlin/config-full/system-proprietary-blobs-api26.txt
@@ -11,7 +11,6 @@ system/etc/firmware/wcd9320/wcd9320_anc.bin
 system/etc/firmware/wcd9320/wcd9320_mad_audio.bin
 system/etc/firmware/wcd9320/wcd9320_mbhc.bin
 system/etc/old-apns-conf.xml
-system/etc/permissions/com.android.ims.rcsmanager.xml
 system/etc/permissions/com.android.omadm.service.xml
 system/etc/permissions/com.android.sdm.plugins.connmo.xml
 system/etc/permissions/com.android.sdm.plugins.sprintdm.xml

--- a/marlin/config-naked/system-proprietary-blobs-api26.txt
+++ b/marlin/config-naked/system-proprietary-blobs-api26.txt
@@ -11,7 +11,6 @@ system/etc/firmware/wcd9320/wcd9320_anc.bin
 system/etc/firmware/wcd9320/wcd9320_mad_audio.bin
 system/etc/firmware/wcd9320/wcd9320_mbhc.bin
 system/etc/old-apns-conf.xml
-system/etc/permissions/com.android.ims.rcsmanager.xml
 system/etc/permissions/privapp-permissions-marlin.xml
 system/etc/sysconfig/nexus.xml
 system/lib64/libaptX_encoder.so

--- a/sailfish/config-full/system-proprietary-blobs-api26.txt
+++ b/sailfish/config-full/system-proprietary-blobs-api26.txt
@@ -11,7 +11,6 @@ system/etc/firmware/wcd9320/wcd9320_anc.bin
 system/etc/firmware/wcd9320/wcd9320_mad_audio.bin
 system/etc/firmware/wcd9320/wcd9320_mbhc.bin
 system/etc/old-apns-conf.xml
-system/etc/permissions/com.android.ims.rcsmanager.xml
 system/etc/permissions/com.android.omadm.service.xml
 system/etc/permissions/com.android.sdm.plugins.connmo.xml
 system/etc/permissions/com.android.sdm.plugins.sprintdm.xml

--- a/sailfish/config-naked/system-proprietary-blobs-api26.txt
+++ b/sailfish/config-naked/system-proprietary-blobs-api26.txt
@@ -11,7 +11,6 @@ system/etc/firmware/wcd9320/wcd9320_anc.bin
 system/etc/firmware/wcd9320/wcd9320_mad_audio.bin
 system/etc/firmware/wcd9320/wcd9320_mbhc.bin
 system/etc/old-apns-conf.xml
-system/etc/permissions/com.android.ims.rcsmanager.xml
 system/etc/permissions/privapp-permissions-marlin.xml
 system/etc/sysconfig/nexus.xml
 system/lib64/libaptX_encoder.so


### PR DESCRIPTION
Since com.android.ims.rcsmanager is included as a module, it already
pulls in com.android.ims.rcsmanager.xml as a dependency.