### PR TITLE
remove DiagMon from Pixel naked configuration

### DIFF
--- a/marlin/config-naked/bytecode-proprietary-api26.txt
+++ b/marlin/config-naked/bytecode-proprietary-api26.txt
@@ -2,7 +2,6 @@
 
 # Radio
 system/priv-app/CNEService/CNEService.apk
-system/priv-app/DiagMon/DiagMon.apk
 system/priv-app/qcrilmsgtunnel/qcrilmsgtunnel.apk
 
 # Wifi Calling

--- a/sailfish/config-naked/bytecode-proprietary-api26.txt
+++ b/sailfish/config-naked/bytecode-proprietary-api26.txt
@@ -2,7 +2,6 @@
 
 # Radio
 system/priv-app/CNEService/CNEService.apk
-system/priv-app/DiagMon/DiagMon.apk
 system/priv-app/qcrilmsgtunnel/qcrilmsgtunnel.apk
 
 # Wifi Calling


### PR DESCRIPTION
This app appears to be a plugin for the DMService / SprintDM
infrastructure that's not being included. It doesn't appear to be
integrated anywhere and serves no useful purpose by itself. Nothing
breaks in the telephony tests with it removed.