### PR TITLE
set LOCAL_DEX_PREOPT := false for RROs

### DIFF
--- a/scripts/generate-vendor.sh
+++ b/scripts/generate-vendor.sh
@@ -679,6 +679,7 @@ gen_mk_for_bytecode() {
       # Overlay APKs should only contain resource files
       if [[ "$relSubRoot" =~ ^overlay/.* ]]; then
         echo "LOCAL_IS_RUNTIME_RESOURCE_OVERLAY := true"
+        echo "LOCAL_DEX_PREOPT := false"
       fi
 
       echo 'include $(BUILD_PREBUILT)'


### PR DESCRIPTION
Trying to use dexpreopt with Runtime Resource Overlays will break:

    dex2oatd E 10-03 23:19:50 18417 18417 oat_writer.cc:403] No dex files in zip file '/vendor/overlay/Pixel/PixelThemeOverlay.apk': Entry not found

CopperheadOS plans to enable dexpreopt for vendor again in order to ban
executing dalvikcache_data_file for the base system again and this was
getting in the way.