### PR TITLE
Implement factory zip caching/reusing

### DIFF
--- a/scripts/download-nexus-image.sh
+++ b/scripts/download-nexus-image.sh
@@ -169,6 +169,6 @@ fi
 
 echo "[*] Downloading image from '$url'"
 outFile=$OUTPUT_DIR/$(basename "$url")
-wget -O "$outFile" "$url"
+wget --continue -O "$outFile" "$url"
 
 abort 0


### PR DESCRIPTION
This causes wget to not re-download a perfectly happy, successfully downloaded factory zip file if the script terminates at a later stage and needs to be re-executed.

Closes: #120