### PR TITLE
avoid treating vendor as a radio file

### DIFF
--- a/scripts/generate-vendor.sh
+++ b/scripts/generate-vendor.sh
@@ -398,7 +398,6 @@ gen_board_family_cfg_mk() {
     {
       echo "# [$EXEC_DATE] Auto-generated file, do not edit"
       echo ""
-      echo 'AB_OTA_PARTITIONS += vendor'
       echo 'ifneq ($(filter sailfish,$(TARGET_DEVICE)),)'
       echo '  LOCAL_STEM := sailfish/BoardConfigVendorPartial.mk'
       echo 'else'
@@ -885,7 +884,7 @@ update_ab_ota_partitions() {
 
   {
     echo "# Partitions to add in AB OTA images"
-    echo 'AB_OTA_PARTITIONS += \'
+    echo 'AB_OTA_PARTITIONS += vendor \'
     for partition in "${EXTRA_IMGS[@]}"
     do
       echo "    $partition \\"

--- a/taimen/config.json
+++ b/taimen/config.json
@@ -19,7 +19,6 @@
     "pmic",
     "rpm",
     "tz",
-    "vendor",
     "xbl"
   ],
   "AndroidMk": "taimen/Android.mk",

--- a/walleye/config.json
+++ b/walleye/config.json
@@ -19,7 +19,6 @@
     "pmic",
     "rpm",
     "tz",
-    "vendor",
     "xbl"
   ],
   "AndroidMk": "walleye/Android.mk",


### PR DESCRIPTION
This avoids generating an incorrect add-radio-file call for the vendor
image, causing the stock factory image to be included and flashed by the
factory images and breaking booting. It moves the marlin vendor image
inclusion to the shared AB_OTA_PARTITIONS generation so it gets applied
for taimen / walleye too.