### PR TITLE
Make factory download image grep more specific

### DIFF
--- a/scripts/download-nexus-image.sh
+++ b/scripts/download-nexus-image.sh
@@ -161,7 +161,7 @@ fi
 
 # Then retrieve the index page
 url=$(curl -L -b "$COOKIE_FILE" --silent -H "X_XSRFToken: $xsrf_token" "$GURL" | \
-      grep -i "<a href=.*$DEV_ALIAS-$BUILDID" | cut -d '"' -f2)
+      grep -i "<a href=.*$DEV_ALIAS-$BUILDID-" | cut -d '"' -f2)
 if [ "$url" == "" ]; then
   echo "[-] Image URL not found"
   abort 1


### PR DESCRIPTION
The September build naming for marlin/sailfish (ppr2.180905.006) breaks the current download-nexus-image.sh script as it ends up getting two images instead of one (as there is also a marlin-ppr2.180905.006.a1).


    curl ... "https://developers.google.com/android/nexus/images" | grep -i "<a href=.*marlin-ppr2.180905.006"
    <td><a href="https://dl.google.com/dl/android/aosp/marlin-ppr2.180905.006-factory-df8ec974.zip"
    <td><a href="https://dl.google.com/dl/android/aosp/marlin-ppr2.180905.006.a1-factory-a78fe264.zip"
