### PR TITLE
remove product from radio images

### DIFF
--- a/blueline/config.json
+++ b/blueline/config.json
@@ -15,7 +15,6 @@
     "hyp",
     "keymaster",
     "modem",
-    "product",
     "qupfw",
     "tz",
     "xbl",

--- a/crosshatch/config.json
+++ b/crosshatch/config.json
@@ -15,7 +15,6 @@
     "hyp",
     "keymaster",
     "modem",
-    "product",
     "qupfw",
     "tz",
     "xbl",


### PR DESCRIPTION
This is already provided by AOSP for blueline/crosshatch:

    # product.img
    BOARD_PRODUCTIMAGE_PARTITION_SIZE := 314572800
    BOARD_PRODUCTIMAGE_FILE_SYSTEM_TYPE := ext4
    TARGET_COPY_OUT_PRODUCT := product

Including this as a radio image has unclear consequences and appears to
be incorrect.

Closes #155