### PR TITLE
remove com.google.android.factoryota.xml

### DIFF
--- a/blueline/config.json
+++ b/blueline/config.json
@@ -63,7 +63,6 @@
         "system/etc/firmware/music_detector.descriptor",
         "system/etc/firmware/music_detector.sound_model",
         "system/etc/permissions/cneapiclient.xml",
-        "system/etc/permissions/com.google.android.factoryota.xml",
         "system/etc/permissions/com.google.modemservice.xml",
         "system/etc/permissions/com.qualcomm.qti.imscmservice.xml",
         "system/etc/permissions/com.quicinc.cne.xml",

--- a/crosshatch/config.json
+++ b/crosshatch/config.json
@@ -63,7 +63,6 @@
         "system/etc/firmware/music_detector.descriptor",
         "system/etc/firmware/music_detector.sound_model",
         "system/etc/permissions/cneapiclient.xml",
-        "system/etc/permissions/com.google.android.factoryota.xml",
         "system/etc/permissions/com.google.modemservice.xml",
         "system/etc/permissions/com.qualcomm.qti.imscmservice.xml",
         "system/etc/permissions/com.quicinc.cne.xml",


### PR DESCRIPTION
This is no longer present in the latest PQ3A.190505.002 release and this
app was not being included anyway.