### PR TITLE
Let the Pixel 3 and 3a co-exist with their bigger brothers

### DIFF
--- a/scripts/generate-vendor.sh
+++ b/scripts/generate-vendor.sh
@@ -1215,7 +1215,8 @@ update_vendor_blobs_mk "$BLOBS_LIST"
 
 # Generate device-vendor.mk makefile (will be updated later)
 echo "[*] Generating '$(basename "$DEVICE_VENDOR_MK")'"
-echo -e "\$(call inherit-product, vendor/$VENDOR_DIR/$DEVICE/$DEVICE-vendor-blobs.mk)\n" >> "$DEVICE_VENDOR_MK"
+echo -e "VENDOR_DEVICE := \$(TARGET_PRODUCT:aosp_%=%)" >> "$DEVICE_VENDOR_MK"
+echo -e "\$(call inherit-product, vendor/$VENDOR_DIR/\$(VENDOR_DEVICE)/\$(VENDOR_DEVICE)-vendor-blobs.mk)\n" >> "$DEVICE_VENDOR_MK"
 
 # Append items listed in device vendor configuration file
 {


### PR DESCRIPTION
Generic solution, implemented for all devices, can put it behind a flag if needed.

Should be fine everywhere either way.