### PR TITLE
use bracketed object accessor syntax for older jq versions

### DIFF
--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -68,7 +68,7 @@ jqRawStrTop() {
   local query="$1"
   local conf_file="$2"
 
-  jq -r ".\"$query\"" "$conf_file" || {
+  jq -r ".[\"$query\"]" "$conf_file" || {
     echo "[-] json raw top string parse failed" >&2
     abort 1
   }
@@ -78,7 +78,7 @@ jqIncRawArrayTop() {
   local query="$1"
   local conf_file="$2"
 
-  jq -r ".\"$query\"[]" "$conf_file" || {
+  jq -r ".[\"$query\"][]" "$conf_file" || {
     echo "[-] json top raw string string parse failed" >&2
     abort 1
   }
@@ -90,7 +90,7 @@ jqRawStr() {
   local query="$3"
   local conf_file="$4"
 
-  jq -r ".\"$api\".\"$conf\".\"$query\"" "$conf_file" || {
+  jq -r ".[\"$api\"][\"$conf\"][\"$query\"]" "$conf_file" || {
     echo "[-] json raw string parse failed" >&2
     abort 1
   }
@@ -102,7 +102,7 @@ jqIncRawArray() {
   local query="$3"
   local conf_file="$4"
 
-  jq -r ".\"$api\".naked.\"$query\"[]" "$conf_file" || {
+  jq -r ".[\"$api\"].naked[\"$query\"][]" "$conf_file" || {
     echo "[-] json raw string array parse failed" >&2
     abort 1
   }
@@ -111,7 +111,7 @@ jqIncRawArray() {
     return
   fi
 
-  jq -r ".\"$api\".full.\"$query\"[]" "$conf_file" || {
+  jq -r ".[\"$api\"].full[\"$query\"][]" "$conf_file" || {
     echo "[-] json raw string array parse failed" >&2
     abort 1
   }


### PR DESCRIPTION
As described in #166, the scripts may fail when parsing a device's `config.json` due to incorrect syntax with jq version 1.3 or below. This updates the filter strings passed to jq to use syntax that is compatible with both older and newer versions of jq.

## Rationale

Although this repo ships with a jq v1.5 executable, it's nice to be able to use the system installed jq from your favorite distro's official package repositories. Particularly, official Android documentation suggests Ubuntu 14.04, whose official repositories only provide jq v1.3.