### PR TITLE
fix "Nexus accept ToS failed" error with ToS agreement during download

### DIFF
--- a/scripts/constants.sh
+++ b/scripts/constants.sh
@@ -20,7 +20,6 @@ declare -ra SUPPORTED_DEVICES=(
 # URLs to download factory images from
 readonly NID_URL="https://google.com"
 readonly GURL="https://developers.google.com/android/nexus/images"
-readonly TOSURL="https://developers.google.com/profile/acknowledgeNotification"
 
 # oatdump dependencies URLs as compiled from AOSP matching API levels
 readonly L_OATDUMP_URL_API23='https://onedrive.live.com/download?cid=D1FAC8CC6BE2C2B0&resid=D1FAC8CC6BE2C2B0%21490&authkey=ACA4f4Zvs3Tb_SY'

--- a/scripts/download-nexus-image.sh
+++ b/scripts/download-nexus-image.sh
@@ -36,16 +36,17 @@ accept_tos() {
   # Message based on 'October 3, 2016' update
   cat << EOF
 
---{ Google Terms and Conditions
+--{ Google Terms and Conditions [1]
 Downloading of the system image and use of the device software is subject to the
-Google Terms of Service [1]. By continuing, you agree to the Google Terms of
-Service [1] and Privacy Policy [2]. Your downloading of the system image and use
+Google Terms of Service [2]. By continuing, you agree to the Google Terms of
+Service [2] and Privacy Policy [3]. Your downloading of the system image and use
 of the device software may also be subject to certain third-party terms of
 service, which can be found in Settings > About phone > Legal information, or as
 otherwise provided.
 
-[1] https://www.google.com/intl/en/policies/terms/
-[2] https://www.google.com/intl/en/policies/privacy/
+[1] https://developers.google.com/android/images#legal
+[2] https://www.google.com/intl/en/policies/terms/
+[3] https://www.google.com/intl/en/policies/privacy/
 
 EOF
 
@@ -148,19 +149,9 @@ done
 
 # Accept news ToS page
 accept_tos
-xsrf_token=$(curl -L -b "$COOKIE_FILE" --silent "$GURL" | \
-             grep -io "<meta name=\"xsrf_token\" content=\".*\" />" | \
-             cut -d '"' -f4)
-response=$(curl -b "$COOKIE_FILE" -X POST -d "notification_id=wall-nexus-image-tos" \
-           -H "X_XSRFToken: $xsrf_token" --write-out "%{http_code}" --output /dev/null \
-           --silent "$TOSURL")
-if [[ "$response" != "200" ]]; then
-  echo "[-] Nexus ToS accept request failed"
-  abort 1
-fi
 
 # Then retrieve the index page
-url=$(curl -L -b "$COOKIE_FILE" --silent -H "X_XSRFToken: $xsrf_token" "$GURL" | \
+url=$(curl -L -b "$COOKIE_FILE" --silent "$GURL" | \
       grep -i "<a href=.*$DEV_ALIAS-$BUILDID-" | cut -d '"' -f2)
 if [ "$url" == "" ]; then
   echo "[-] Image URL not found"


### PR DESCRIPTION
This PR corrects the issue where attempting to download system images fails with the error "Nexus accept ToS failed", Also of note, the XSRF token in the HTTP request doesn't seem to be needed anymore. presumably due to Google serverside changes.

Tested on my Gentoo buildserver with one of the blueline system images (as an example), and it succeeds.